### PR TITLE
Fix CI

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -5,7 +5,7 @@ extraction:
         - p7zip-full
     after_prepare:
     - export GCC=gcc-arm-none-eabi-9-2020-q2-update
-    - export CH_VER=stable_20.3.x
+    - export CH_VER=master
     - cd ${LGTM_WORKSPACE}
     - wget -nv https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2 -O compiler.tar.xz
     - tar xf compiler.tar.xz -C ${LGTM_WORKSPACE}


### PR DESCRIPTION
This should fix the LGTM CI that was failing in https://github.com/ChibiOS/ChibiOS-Contrib/pull/310
Previously used the `20.3.x stable` branch
Changed to use the master branch 

Not sure if CI is based on the original branch, or the branch being pulled.